### PR TITLE
Documentation cleanup

### DIFF
--- a/overdrive_reconcile/overdrive_session.py
+++ b/overdrive_reconcile/overdrive_session.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 def get_overdrive_api_creds(library: str) -> None:
     """
-    Retrieves Overdrive API credentials for 'NYPL' or 'BPL' library
+    Retrieves Overdrive API credentials for the given library.
     Args:
         library: 'NYPL' or 'BPL'
     Returns:
-        API credentials for the given library as a dictionary
+        None. Credentials are loaded into environment variables.
     """
     library = library.upper()
     if library == "NYPL":
@@ -46,7 +46,8 @@ def get_overdrive_api_creds(library: str) -> None:
 def get_inventory(library: str) -> None:
     """
     Retrieves a list of registry IDs from the Overload Digital Inventory API
-    representing the given library's entire digital collection.
+    representing the given library's entire digital collection. The results
+    are saved to a csv (eg. 'NYPL-overdrive-api-reserve-ids.csv').
     Args:
         library: 'NYPL' or 'BPL'
     Returns:
@@ -68,6 +69,18 @@ def get_inventory(library: str) -> None:
 
 
 def refresh_collection_token(creds: dict[str, str], cred_file: str) -> dict[str, str]:
+    """
+    Retrieve a new collection token for a given library and write the collection token
+    to a yaml file containing that library's API credentials.
+
+    Args:
+        creds: the library's API credentials as a dictionary
+        cred_file: the file name where the credentials should be written
+
+    Returns:
+        the library's API credentials as a dictionary with a new collection token
+        and collection token expiration
+    """
     token = OverdriveAccessToken(key=creds["CLIENT_KEY"], secret=creds["CLIENT_SECRET"])
     with OverdriveSession(authorization=token) as session:
         response = session.get_library_account_info(int(creds["LIBRARY_ID"]))
@@ -80,6 +93,7 @@ def refresh_collection_token(creds: dict[str, str], cred_file: str) -> dict[str,
 
 
 def expired_coll_token(token_expire: str) -> bool:
+    """Check whether a collection token has expired."""
     today = datetime.datetime.now()
     if datetime.datetime.strptime(token_expire, "%Y-%m-%d") >= today:
         return False
@@ -87,11 +101,30 @@ def expired_coll_token(token_expire: str) -> bool:
 
 
 def get_batches(iterable: list[str], size: int) -> Generator[list[str], None, None]:
+    """Divide list of IDs into chunks to allow for batch API queries."""
     for i in range(0, len(iterable), size):
         yield iterable[i : i + size]
 
 
 def verify_missing_resources(library: str, df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Query the Overdrive Metadata API to confirm the availability of titles whose reserve
+    IDs have been identified as lacking records in Sierra.
+
+    This check is conducted using the list of reserve IDs representing titles missing
+    records in Sierra. The list is created from the outer merge of reserve IDs in
+    Overdrive records exported from Sierra and reserve IDs retrieved from the Overdrive
+    Digital Inventory API. This check is necessary in order to confirm that a record
+    should be imported into Sierra because the library has an active license for the
+    title.
+
+    Args:
+        library: 'NYPL' or 'BPL'
+        df: a `pandas.DataFrame` object containing a list of reserve IDs to be checked
+    Returns:
+        a `pandas.DataFrame` object containing only those reserve IDs from the input
+        that have active licenses.
+    """
     token = OverdriveAccessToken(
         key=os.environ[f"{library}_CLIENT_KEY"],
         secret=os.environ[f"{library}_CLIENT_SECRET"],

--- a/overdrive_reconcile/overdrive_session.py
+++ b/overdrive_reconcile/overdrive_session.py
@@ -37,7 +37,7 @@ def get_overdrive_api_creds(library: str) -> None:
         raise ValueError("Invalid library code passed")
     with open(os.path.join(os.environ["USERPROFILE"], fh), "r") as f:
         data = yaml.safe_load(f)
-    if expired_coll_token(data["COLL_TOKEN_EXPIRATION"]):
+    if expired_coll_token(data.get("COLL_TOKEN_EXPIRATION")):
         data = refresh_collection_token(
             creds=data, cred_file=os.path.join(os.environ["USERPROFILE"], fh)
         )
@@ -98,7 +98,7 @@ def refresh_collection_token(creds: dict[str, str], cred_file: str) -> dict[str,
 def expired_coll_token(token_expire: str) -> bool:
     """Check whether a collection token has expired."""
     today = datetime.datetime.now()
-    if datetime.datetime.strptime(token_expire, "%Y-%m-%d") >= today:
+    if token_expire and datetime.datetime.strptime(token_expire, "%Y-%m-%d") >= today:
         return False
     return True
 

--- a/overdrive_reconcile/overdrive_session.py
+++ b/overdrive_reconcile/overdrive_session.py
@@ -17,8 +17,10 @@ logger = logging.getLogger(__name__)
 def get_overdrive_api_creds(library: str) -> None:
     """
     Retrieves Overdrive API credentials for the given library.
+
     Args:
         library: 'NYPL' or 'BPL'
+
     Returns:
         None. Credentials are loaded into environment variables.
     """

--- a/overdrive_reconcile/overdrive_session.py
+++ b/overdrive_reconcile/overdrive_session.py
@@ -66,6 +66,7 @@ def get_inventory(library: str) -> None:
         response = session.get_collection_inventory(collectionToken=coll_token)
         inventory = session.get(response.json()["files"][0]["fileUrl"])
         out.extend(inventory.json()["reserveIds"])
+    out = [i.lower() for i in out]
     df = pd.DataFrame(out)
     df.to_csv(out_file, index=False, header=False)
 

--- a/overdrive_reconcile/prep.py
+++ b/overdrive_reconcile/prep.py
@@ -1,3 +1,5 @@
+"""Functions that prepare Sierra export files for reconciliation."""
+
 import logging
 import os
 
@@ -23,22 +25,28 @@ def fresh_start(files: list[str]) -> None:
 
 def prep_reserve_ids_in_sierra_export(library: str, src_fh: str) -> None:
     """
-    Filters and prepares OverDrive Reserve IDs exported to text file
-    from Sierra for further analysis.
-    It's common to see print orders attached to e-resource bib. It is important
-    to make sure the list from Sierra does not include any mistakenly included
-    records!
+    Validates OverDrive Reserve IDs exported from Sierra for further analysis.
 
-    Sierra export configuration:
-        fields: "RECORD #(BIBLIO)","037|a"
-        field delimiter: ,
-        repeated field delimiter: ;
-        text qualifier: "
-        maximum field lenght: <none>
+    It's common to see print orders attached to e-resource bib records and these
+    records must be filtered out in order to ensure they are not included in the
+    reconciliation.
+
+    See 'Step 2. Sierra list creation & export' in this package's README for the
+    required format of the Sierra export file.
+
+    The 'files/{library}/{date}' directory is cleaned up removing any existing files
+    named '{library}-sierra-prepped-reserve-ids.csv' or
+    '{library}-sierra-rejected-not-overdrive-ids.csv' resulting from previous jobs
+    before outputing the validated and rejected reserve IDs to their respective files.
 
     Args:
-        src_fh:                 file handle of Sierra text export
-        library:                library code: 'NYPL' or 'BPL'
+        src_fh: file handle of Sierra .txt export
+        library: 'NYPL' or 'BPL'
+
+    Returns:
+        None. Reserve IDs are written to csvs containing valid IDs (eg.
+        'NYPL-sierra-prepped-reserve-ids.csv') and rejected IDs (eg.
+        'NYPL-sierra-rejected-not-overdrive-ids.csv')
     """
     dst_validated_fh = create_dst_csv_fh(library, "sierra-prepped-reserve-ids")
     dst_rejected_fh = create_dst_csv_fh(library, "sierra-rejected-not-overdrive-ids")

--- a/overdrive_reconcile/reconcile.py
+++ b/overdrive_reconcile/reconcile.py
@@ -33,21 +33,20 @@ def dedup_on_reserve_id(library: str, df: pd.DataFrame, subdir: str) -> None:
         '{library}-FINAL-duplicate-reserveid-sierra.csv'. Unique reserve IDs are
         written to '{library}-unique-reserveid-sierra.csv'.
     """
-    logger.debug("Deduplication of Sierra dataset on Reserve ID.")
     dups_fh = f"{subdir}/{library}-FINAL-duplicate-reserveid-sierra.csv"
     unique_fh = f"{subdir}/{library}-unique-reserveid-sierra.csv"
 
     ddf = df[df.duplicated(subset=["reserve_id"], keep="last")]
     ddf.to_csv(dups_fh, index=False, header=False, columns=["bib_no", "reserve_id"])
     logger.info(
-        f"Identified {ddf.shape[0]} duplicate records in Sierra export. "
+        f"Identified {ddf.shape[0]} duplicate record(s) in Sierra export. "
         f"Report saved to: {dups_fh}"
     )
 
     udf = df.drop_duplicates(subset=["reserve_id"], keep="last")
     udf.to_csv(unique_fh, index=False, header=False, columns=["bib_no", "reserve_id"])
     logger.info(
-        f"Identified {udf.shape[0]} unique Reserve IDs in Sierra export. "
+        f"Identified {udf.shape[0]} unique reserve ID(s) in Sierra export. "
         f"Report saved to: {unique_fh}"
     )
 
@@ -68,7 +67,7 @@ def reconcile(library: str, sierra_export_fh: str) -> None:
     # load api creds into envars
     get_overdrive_api_creds(library=library)
 
-    # reports directory
+    # create directory for output files
     subdir = date_subdirectory(library)
     logger.debug(f"All output reports will be saved to {subdir}.")
 
@@ -85,13 +84,12 @@ def reconcile(library: str, sierra_export_fh: str) -> None:
     logger.debug("Parsing Sierra Export data.")
     prep_reserve_ids_in_sierra_export(library, sierra_export_fh)
 
-    # prepare data from Overdrive Digital Inventory API
-    logger.debug(f"Retrieving data from {library} Overdrive Digital Inventory API.")
+    # retrieve data from Overdrive Digital Inventory API
+    logger.debug(f"Retrieving data from Overdrive Digital Inventory API for {library}.")
     get_inventory(library)
 
-    # merge both datasets
-    # retireve Sierra data
-    logger.debug("Merging Sierra and Overdrive API sets.")
+    # read prepped Sierra export data and deduplicate reserve IDs
+    logger.debug("Deduplicating Sierra export data on reserve ID.")
     df = pd.read_csv(
         f"{subdir}/{library}-sierra-prepped-reserve-ids.csv",
         names=["bib_no", "reserve_id"],
@@ -99,7 +97,7 @@ def reconcile(library: str, sierra_export_fh: str) -> None:
     dedup_on_reserve_id(library, df, subdir)
 
     # use deduped sierra reserve ids for analysis
-    logger.debug("Normalizing Sierra and Overdrive API Reserve IDs.")
+    logger.debug("Launching analysis.")
     sdf = pd.read_csv(
         f"{subdir}/{library}-unique-reserveid-sierra.csv",
         names=["bib_no", "reserve_id"],
@@ -110,8 +108,8 @@ def reconcile(library: str, sierra_export_fh: str) -> None:
     )
     edf["reserve_id"] = edf["reserve_id"].str.lower()
 
-    logger.debug("Launching analysis.")
-    # find inner joint (available - present in both sets)
+    # create inner join representing available resources (ie. IDs present in both sets)
+    logger.debug("Merging Sierra and Overdrive API sets.")
     adf = pd.merge(sdf, edf, on="reserve_id")
     adf["url"] = url + adf["reserve_id"].astype(str)
 
@@ -119,34 +117,35 @@ def reconcile(library: str, sierra_export_fh: str) -> None:
         avail_fh, index=False, header=False, columns=["bib_no", "reserve_id", "url"]
     )
     logger.info(
-        f"Identified {df.shape[0]} resources available. Report saved to: {avail_fh}"
+        f"Identified {adf.shape[0]} available resource(s). Report saved to: {avail_fh}"
     )
 
     # create full union of both sets
     logger.debug("Creating full union of both sets.")
     fdf = pd.merge(sdf, edf, on="reserve_id", how="outer", indicator=True)
 
-    # find missing resources
-    logger.debug("Identifying Reserve IDs missing from Sierra.")
+    # find missing resources (ie. IDs only present in Overdrive export)
+    logger.debug("Identifying reserve IDs missing from Sierra.")
     cdf = fdf[fdf["_merge"] == "right_only"].copy()
     cdf.to_csv(import_fh, index=False, header=False, columns=["reserve_id"])
 
+    # verify that missing resources have active licenses
     mdf = verify_missing_resources(library=library, df=cdf)
     mdf["url"] = url + mdf["reserve_id"].astype(str)
     mdf.to_csv(miss_fh, index=False, header=False, columns=["reserve_id", "url"])
     logger.info(
-        f"Identified {mdf.shape[0]} missing resources. Report saved to: {miss_fh}"
+        f"Identified {mdf.shape[0]} missing resource(s). Report saved to: {miss_fh}"
     )
 
-    # find resources for deletion
-    logger.debug("Finding resources to be deleted in Sierra.")
+    # find resources to be deleted (ie. IDs only present in Sierra export)
+    logger.debug("Finding resources to be deleted from Sierra.")
     ddf = fdf[fdf["_merge"] == "left_only"].copy()
     ddf["url"] = url + ddf["reserve_id"].astype(str)
     ddf.to_csv(
         del_fh, index=False, header=False, columns=["bib_no", "reserve_id", "url"]
     )
     logger.info(
-        f"Identified {ddf.shape[0]} resources that can be deleted from Sierra. "
+        f"Identified {ddf.shape[0]} resource(s) that can be deleted from Sierra. "
         f"Report saved to: {del_fh}"
     )
 

--- a/overdrive_reconcile/reconcile.py
+++ b/overdrive_reconcile/reconcile.py
@@ -1,6 +1,4 @@
-"""
-The main module that runs the reconciliation process.
-"""
+"""The main module that runs the reconciliation process."""
 
 import logging
 import os
@@ -22,13 +20,18 @@ logger = logging.getLogger(__name__)
 def dedup_on_reserve_id(library: str, df: pd.DataFrame, subdir: str) -> None:
     """
     Deduplicates given dataframe on reserve ID leaving the latest record.
-    Does not consiter situation where duplicate reserve ID is present on the
-    same record.
+    Does not consider the situation where a single bib record contains duplicate
+    reserve IDs.
 
     Args:
-        library:                    'NYPL' or 'BPL' library  code
-        df:                         pandas.DataFrame instance
-        subdir:                     directory to output reports
+        library: 'NYPL' or 'BPL'
+        df: `pandas.DataFrame` object to deduplicate
+        subdir: directory where output .csv files will be written
+
+    Returns:
+        None. Bib IDs for records containing duplicate reserve IDs are written to
+        '{library}-FINAL-duplicate-reserveid-sierra.csv'. Unique reserve IDs are
+        written to '{library}-unique-reserveid-sierra.csv'.
     """
     logger.debug("Deduplication of Sierra dataset on Reserve ID.")
     dups_fh = f"{subdir}/{library}-FINAL-duplicate-reserveid-sierra.csv"
@@ -51,7 +54,16 @@ def dedup_on_reserve_id(library: str, df: pd.DataFrame, subdir: str) -> None:
 
 def reconcile(library: str, sierra_export_fh: str) -> None:
     """
-    Launches recoinciliation process
+    Launches reconciliation process for `reconcile` command in `run.py`.
+
+    Args:
+        library:
+            'NYPL' or 'BPL'
+        sierra_export_fh:
+            path to .txt file containing bib IDs and reserve IDs exported from Sierra
+
+    Returns:
+        None. Output is written to .csv files in 'files/{library}/{date}/'.
     """
     # load api creds into envars
     get_overdrive_api_creds(library=library)

--- a/overdrive_reconcile/reconcile.py
+++ b/overdrive_reconcile/reconcile.py
@@ -36,6 +36,7 @@ def dedup_on_reserve_id(library: str, df: pd.DataFrame, subdir: str) -> None:
     dups_fh = f"{subdir}/{library}-FINAL-duplicate-reserveid-sierra.csv"
     unique_fh = f"{subdir}/{library}-unique-reserveid-sierra.csv"
 
+    df["reserve_id"] = df["reserve_id"].str.lower()
     ddf = df[df.duplicated(subset=["reserve_id"], keep="last")]
     ddf.to_csv(dups_fh, index=False, header=False, columns=["bib_no", "reserve_id"])
     logger.info(
@@ -102,11 +103,9 @@ def reconcile(library: str, sierra_export_fh: str) -> None:
         f"{subdir}/{library}-unique-reserveid-sierra.csv",
         names=["bib_no", "reserve_id"],
     )
-    sdf["reserve_id"] = sdf["reserve_id"].str.lower()
     edf = pd.read_csv(
         f"{subdir}/{library}-overdrive-api-reserve-ids.csv", names=["reserve_id"]
     )
-    edf["reserve_id"] = edf["reserve_id"].str.lower()
 
     # create inner join representing available resources (ie. IDs present in both sets)
     logger.debug("Merging Sierra and Overdrive API sets.")

--- a/overdrive_reconcile/webscraper.py
+++ b/overdrive_reconcile/webscraper.py
@@ -1,5 +1,5 @@
 """
-Use to validate Sierra-Overdrive API deletions
+Scrape Overdrive website for license data to validate list of resources to be deleted.
 """
 
 import csv
@@ -35,11 +35,17 @@ class EbookStatus:
 
 def scrape(library: str, src_fh: str, start: int = 0) -> None:
     """
-    Launches web scraping of OverDrive catalog
+    Launches web scraping of OverDrive catalog from `reconcile` `webscrape` command.
 
     Args:
-        library:                library code
-        src_fh:                 source data file handle
+        library: 'NYPL' or 'BPL'
+        src_fh: path to file containing reserve IDs to be verified.
+        start: the first row within `src_fh` containing the ID to be verified
+
+    Returns:
+        None. Reserve IDs for records to be deleted from Sierra is written to
+        '{library}-FINAL-for-deletion-verified-resources.csv' and records which were
+        falsely identified are written to '{library}-false-positives-for-deletion.csv'.
     """
     with open(src_fh, "r") as count:
         total = sum(1 for line in count)
@@ -65,18 +71,22 @@ def scrape(library: str, src_fh: str, start: int = 0) -> None:
                     else:
                         save2csv(reject_fh, row)
             n += 1
+            time.sleep(0.5)
 
 
 def get_ebook_status(html: bytes) -> EbookStatus:
     """
-    parses HTML, finds significant portion of metadata in document head, and
-    interprets important bits, such as availability of ebook, ownership,
-    available copies, and own copies by the library
+    Parses HTML to determine whether the resource is still available.
 
-    args:
-        html: response.content
-    returns:
-        (available, owned, copies_available, copies_owned): namedtuple
+    The parser first searches for a significant portion of metadata in the document
+    head before interpreting other portions of the html to determine whether the
+    resource is still available or should be deleted.
+
+    Args:
+        html: `bytes` object from `requests.Response.content`
+
+    Returns:
+        `EbookStatus` object containing significant metadata for resource.
     """
 
     ebook_status = EbookStatus()
@@ -94,17 +104,28 @@ def get_html(
     url: str, n: int, total: int, agent: str = "bookops/NYPL"
 ) -> Optional[bytes]:
     """
-    retrieves html code from given url
-    args:
-        url:                    URL of a page to be requested
-        agent:                  agent header of the request
-        n:                      resource sequence #
-        total:                  total number of resources to request
-    returns:
-        page
+    Retrieves HTML for a given url.
+
+    Args:
+        url:
+            URL to be requested
+        n:
+            The sequence number for the resource (ie. the row number from the input csv)
+            to be used in a log message.
+        total:
+            The total number of resources to be requested (ie. the total number of rows
+            in the input csv) to be used in a log message.
+        agent:
+            agent to be added to the header of the request. Default is 'bookops/NYPL'
+
+    Returns:
+        HTML data as a `bytes` object from the `requests.Response.content` attribute
+        if the request is successful. Returns `None` if the request returns a 4xx
+        response.
+
+    Raises:
+        `requests.exceptions.Timeout` if the request times out.
     """
-    # slow things down a bit
-    time.sleep(0.5)
 
     headers = {"user-agent": agent}
 
@@ -124,13 +145,19 @@ def get_html(
 
 def update_status(metadata: str, ebook_status: EbookStatus) -> EbookStatus:
     """
-    finds significant data in html.head.script
-    args:
-        html_head_script: str
-        ebook_status: namedtuple
+    Searches for significant data within a string extracted from HTML head.script
+    tag to determine the current status of an eBook. A resource should not have its
+    record deleted from Sierra if its HTML contains '"availabilityType":"always"',
+    '"isPreReleaseTitle":true', or '"ownedCopies":' with a value greater than zero.
 
-    returns:
-        updated ebook_status
+    Args:
+        metadata:
+            a string extracted from the HTML head.script tag to be parsed for
+            significant metadata
+        ebook_status: `EbookStatus` object
+
+    Returns:
+        An `EbookStatus` object
     """
 
     # title availability

--- a/run.py
+++ b/run.py
@@ -9,7 +9,6 @@ from overdrive_reconcile.webscraper import scrape
 
 
 def main(args: list) -> None:
-    # process: str: library: str, src_fh: str)
     config = logger_dict_config()
     logging.config.dictConfig(config)
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -29,24 +29,25 @@ def test_reconcile(
     assert log_msgs[0].startswith("All output reports will be saved to ")
     assert log_msgs[1] == "Launching reconciliation process."
     assert log_msgs[2] == "Parsing Sierra Export data."
-    assert log_msgs[3] == "Retrieving data from NYPL Overdrive Digital Inventory API."
-    assert log_msgs[4] == "Merging Sierra and Overdrive API sets."
-    assert log_msgs[5] == "Deduplication of Sierra dataset on Reserve ID."
-    assert log_msgs[6].startswith("Identified 0 duplicate records in Sierra export.")
-    assert log_msgs[7].startswith("Identified 3 unique Reserve IDs in Sierra export.")
-    assert log_msgs[8] == "Normalizing Sierra and Overdrive API Reserve IDs."
-    assert log_msgs[9] == "Launching analysis."
-    assert log_msgs[10].startswith("Identified 3 resources available.")
-    assert log_msgs[11] == "Creating full union of both sets."
-    assert log_msgs[12] == "Identifying Reserve IDs missing from Sierra."
-    assert log_msgs[13] == "Checking ids 1-1 of 1."
-    assert log_msgs[14].startswith("Identified 1 missing resources")
-    assert log_msgs[15] == "Finding resources to be deleted in Sierra."
-    assert log_msgs[16].startswith("Identified 2 resources that can be deleted")
-    assert log_msgs[17].startswith("Verifying records for deletion via web scraping")
-    assert log_msgs[18].startswith("(1 of 2) Requested page: http://ebooks.nypl.org/")
-    assert log_msgs[19].startswith("(2 of 2) Requested page: http://ebooks.nypl.org/")
-    assert log_msgs[20] == "Reconciliation complete."
+    assert (
+        log_msgs[3] == "Retrieving data from Overdrive Digital Inventory API for NYPL."
+    )
+    assert log_msgs[4] == "Deduplicating Sierra export data on reserve ID."
+    assert log_msgs[5].startswith("Identified 0 duplicate record(s) in Sierra export.")
+    assert log_msgs[6].startswith("Identified 3 unique reserve ID(s) in Sierra export.")
+    assert log_msgs[7] == "Launching analysis."
+    assert log_msgs[8] == "Merging Sierra and Overdrive API sets."
+    assert log_msgs[9].startswith("Identified 1 available resource(s).")
+    assert log_msgs[10] == "Creating full union of both sets."
+    assert log_msgs[11] == "Identifying reserve IDs missing from Sierra."
+    assert log_msgs[12] == "Checking ids 1-1 of 1."
+    assert log_msgs[13].startswith("Identified 1 missing resource(s)")
+    assert log_msgs[14] == "Finding resources to be deleted from Sierra."
+    assert log_msgs[15].startswith("Identified 2 resource(s) that can be deleted")
+    assert log_msgs[16].startswith("Verifying records for deletion via web scraping")
+    assert log_msgs[17].startswith("(1 of 2) Requested page: http://ebooks.nypl.org/")
+    assert log_msgs[18].startswith("(2 of 2) Requested page: http://ebooks.nypl.org/")
+    assert log_msgs[19] == "Reconciliation complete."
     assert sorted(file_list) == [
         "NYPL-FINAL-available-resources.csv",
         "NYPL-FINAL-duplicate-reserveid-sierra.csv",

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,16 +1,6 @@
 import os
 
-import pandas as pd
-
-from overdrive_reconcile.reconcile import dedup_on_reserve_id, reconcile
-from overdrive_reconcile.utils import date_subdirectory
-
-
-def test_dedup_on_reserve_id():
-    subdir = date_subdirectory("BPL")
-    d = {"bib_no": ["b1", "b2", "b2", "b3"], "reserve_id": [1, 2, 2, 1]}
-    df = pd.DataFrame(data=d)
-    dedup_on_reserve_id("BPL", df, subdir)
+from overdrive_reconcile.reconcile import reconcile
 
 
 def test_reconcile(


### PR DESCRIPTION
## Added
 - docstrings for any functions that did not previously have them.
 - conditional in `get_overdrive_api_creds` that checks if the file contains a collection token and requests one if not.

## Changed
 - Edited and expanded docstrings throughout package
 - log messages that were inaccurate or unnecessary. 

## Removed
 - test for `dedupe_on_reserve_id` from `test_reconcile.py` as it was duplicative